### PR TITLE
[hotfix] Image Domain

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ['fakeimg.pl', 'komic.site', 'komic.tk'],
+    domains: ['fakeimg.pl', 'komic.tk'],
   },
   swcMinify: true,
 }


### PR DESCRIPTION
Remove 'komic.site' from the list of allowed image domains